### PR TITLE
chore(release): gate GitHub release writes by environment

### DIFF
--- a/.github/workflows/release-build-cli.yml
+++ b/.github/workflows/release-build-cli.yml
@@ -127,6 +127,7 @@ jobs:
     name: upload-release-assets
     runs-on: ubuntu-latest
     needs: build
+    environment: github-release
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   finalize:
     runs-on: ubuntu-latest
+    environment: github-release
     env:
       GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- gate draft Release asset uploads behind the `github-release` Environment
- gate final draft-to-public promotion behind the same tag-restricted Environment
- disable administrator bypass on the Environment

## Validation
- `git diff --check`
- required CI runs on this PR
