### PR TITLE
fix(release): prerelease tag safety + dependabot targeting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-
   - package-ecosystem: cargo
     directory: "/rust"
     schedule:
       interval: weekly
-
-  - package-ecosystem: pip
-    directory: "/python"
-    schedule:
-      interval: weekly
-
+    target-branch: develop
   - package-ecosystem: npm
     directory: "/web"
     schedule:
       interval: weekly
+    target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,23 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+
   - package-ecosystem: cargo
     directory: "/rust"
     schedule:
       interval: weekly
     target-branch: develop
+
+  - package-ecosystem: pip
+    directory: "/python"
+    schedule:
+      interval: weekly
+    target-branch: develop
+
   - package-ecosystem: npm
     directory: "/web"
     schedule:

--- a/.github/workflows/release-build-cli.yml
+++ b/.github/workflows/release-build-cli.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Validate release metadata
         shell: bash
-        run: python scripts/release_preflight.py --require-tag
+        run: python scripts/release_preflight.py --require-tag --allow-prerelease-tag
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -145,7 +145,7 @@ jobs:
           python-version: "3.11"
 
       - name: Validate release metadata
-        run: python scripts/release_preflight.py --require-tag
+        run: python scripts/release_preflight.py --require-tag --allow-prerelease-tag
 
       - name: Download build artifacts
         shell: bash

--- a/.github/workflows/release-build-cli.yml
+++ b/.github/workflows/release-build-cli.yml
@@ -167,7 +167,9 @@ jobs:
         shell: bash
         run: |
           tag="${GITHUB_REF_NAME}"
+          # tags with a pre-release suffix (vX.Y.Z-rc.N) must not ship as latest
+          case "${tag}" in *-*) prerelease=(--prerelease) ;; *) prerelease=() ;; esac
           if ! gh release view "${tag}" >/dev/null 2>&1; then
-            gh release create "${tag}" --title "${tag}" --generate-notes --verify-tag --draft
+            gh release create "${tag}" --title "${tag}" --generate-notes --verify-tag --draft "${prerelease[@]}"
           fi
           gh release upload "${tag}" release-assets/* --clobber

--- a/.github/workflows/release-build-desktop.yml
+++ b/.github/workflows/release-build-desktop.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -64,7 +64,7 @@ jobs:
           ls -la dist/${{ matrix.platform }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: mcpstore-desktop-${{ matrix.platform }}
           path: dist/${{ matrix.platform }}/*

--- a/.github/workflows/release-build-desktop.yml
+++ b/.github/workflows/release-build-desktop.yml
@@ -113,8 +113,13 @@ jobs:
         shell: bash
         run: |
           tag="${GITHUB_REF_NAME}"
+          # tags with a pre-release suffix (vX.Y.Z-rc.N) must not ship as latest
+          case "${tag}" in *-*) prerelease=(--prerelease) ;; *) prerelease=() ;; esac
           if ! gh release view "${tag}" >/dev/null 2>&1; then
-            gh release create "${tag}" --title "${tag}" --generate-notes --verify-tag
+            gh release create "${tag}" --title "${tag}" --generate-notes --verify-tag "${prerelease[@]}"
           fi
-          gh release upload "${tag}" dist/darwin-aarch64/*.app.tar.gz dist/darwin-aarch64/*.app.tar.gz.sig \
-            dist/darwin-x86_64/*.app.tar.gz dist/darwin-x86_64/*.app.tar.gz.sig dist/latest.json --clobber
+          assets=(dist/darwin-aarch64/*.app.tar.gz dist/darwin-aarch64/*.app.tar.gz.sig \
+            dist/darwin-x86_64/*.app.tar.gz dist/darwin-x86_64/*.app.tar.gz.sig)
+          # pre-releases must never feed the Tauri auto-updater channel
+          if [ ${#prerelease[@]} -eq 0 ]; then assets+=(dist/latest.json); fi
+          gh release upload "${tag}" "${assets[@]}" --clobber

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -54,16 +54,21 @@ def verify_windows_checkout_paths() -> None:
     print(f"[ok] {len(paths)} release paths are compatible with Windows checkout")
 
 
-def verify_release_tag(expected: str) -> None:
+def verify_release_tag(expected: str, allow_prerelease: bool = False) -> None:
     expected_tag = f"v{expected}"
     ref_type = os.environ.get("GITHUB_REF_TYPE")
     ref_name = os.environ.get("GITHUB_REF_NAME")
-    if ref_type != "tag" or ref_name != expected_tag:
+    tag_ok = ref_name is not None and (
+        ref_name == expected_tag
+        or (allow_prerelease and ref_name.startswith(f"{expected_tag}-"))
+    )
+    if ref_type != "tag" or not tag_ok:
+        hint = f" or a {expected_tag}-<prerelease> tag" if allow_prerelease else ""
         raise SystemExit(
-            f"[error] Release workflow requires tag {expected_tag}; "
+            f"[error] Release workflow requires tag {expected_tag}{hint}; "
             f"received {ref_type or '<unset>'} {ref_name or '<unset>'}"
         )
-    print(f"[ok] release workflow ref matches {expected_tag}")
+    print(f"[ok] release workflow ref matches {ref_name}")
 
 
 def main() -> None:
@@ -73,12 +78,17 @@ def main() -> None:
         action="store_true",
         help="require GITHUB_REF_TYPE/GITHUB_REF_NAME to match the canonical version tag",
     )
+    parser.add_argument(
+        "--allow-prerelease-tag",
+        action="store_true",
+        help="also accept <canonical>-<prerelease> tags (build workflows only; publish stays exact)",
+    )
     args = parser.parse_args()
 
     expected = verify_release_metadata()
     verify_windows_checkout_paths()
     if args.require_tag:
-        verify_release_tag(expected)
+        verify_release_tag(expected, allow_prerelease=args.allow_prerelease_tag)
     print(f"[ok] release metadata is consistent at version {expected}")
 
 


### PR DESCRIPTION
## What
- build workflows: tags with pre-release suffix (vX.Y.Z-rc.N) create GitHub Releases with `--prerelease` (no Latest hijack, no watcher ping)
- desktop workflow: pre-release tags skip `latest.json` upload so the Tauri auto-updater channel is never fed a test build
- preflight: `--allow-prerelease-tag` for build workflows only (publish keeps exact-tag guard, RCs can never reach PyPI/npm/crates)
- `.github/dependabot.yml`: dependabot PRs target `develop` (main stays release-only; config read from default branch lands via separate PR)

## Why
Enables staged releases: accumulate rc builds on release branches (v2.3.1-rc.2 running now) without touching main or shipping to users. Invariant going forward: **merge-to-main and tag happen at the same moment**.