### PR TITLE
chore: add dependabot config targeting develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-
   - package-ecosystem: cargo
     directory: "/rust"
     schedule:
       interval: weekly
-
-  - package-ecosystem: pip
-    directory: "/python"
-    schedule:
-      interval: weekly
-
+    target-branch: develop
   - package-ecosystem: npm
     directory: "/web"
     schedule:
       interval: weekly
+    target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,23 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+
   - package-ecosystem: cargo
     directory: "/rust"
     schedule:
       interval: weekly
     target-branch: develop
+
+  - package-ecosystem: pip
+    directory: "/python"
+    schedule:
+      interval: weekly
+    target-branch: develop
+
   - package-ecosystem: npm
     directory: "/web"
     schedule:


### PR DESCRIPTION
Minimal default-branch config so dependabot PRs open against `develop` (previously all targeted main via UI settings — root cause of main/develop drift). Config file content matches the one flowing to develop via #62.