### PR TITLE
fix(release): restore npm CLI entrypoint and desktop bundle artifacts

### DIFF
--- a/.github/workflows/release-build-desktop.yml
+++ b/.github/workflows/release-build-desktop.yml
@@ -1,6 +1,6 @@
 # Desktop (Tauri) release flow. Runs on the same tags as release-build-cli and
-# uploads updater artifacts (macOS .app.tar.gz + .sig) plus latest.json to the
-# GitHub Release so tauri-plugin-updater can serve updates from:
+# uploads the macOS .dmg plus updater artifacts (.app.tar.gz + .sig) and
+# latest.json to the GitHub Release so tauri-plugin-updater can serve updates from:
 #   https://github.com/ip2a/mcpstore/releases/latest/download/latest.json
 #
 # Required repository secrets:
@@ -34,8 +34,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             platform: darwin-aarch64
-          - target: x86_64-apple-darwin
-            platform: darwin-x86_64
     env:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -53,14 +51,17 @@ jobs:
         working-directory: desktop/tauri
         run: |
           npm i -g @tauri-apps/cli@^2
-          tauri build --target ${{ matrix.target }} --bundles dmg
+          # app bundle is required: createUpdaterArtifacts emits .app.tar.gz/.sig
+          # only when the app target is built; --bundles dmg alone would skip it
+          tauri build --target ${{ matrix.target }} --bundles app,dmg
 
       - name: Collect updater artifacts
         shell: bash
         run: |
           mkdir -p dist/${{ matrix.platform }}
-          bundle="desktop/tauri/target/${{ matrix.target }}/release/bundle/macos"
-          cp "${bundle}"/*.app.tar.gz "${bundle}"/*.app.tar.gz.sig dist/${{ matrix.platform }}/
+          target="desktop/tauri/target/${{ matrix.target }}/release/bundle"
+          cp "${target}/macos"/*.app.tar.gz "${target}/macos"/*.app.tar.gz.sig dist/${{ matrix.platform }}/
+          cp "${target}/dmg"/*.dmg dist/${{ matrix.platform }}/
           ls -la dist/${{ matrix.platform }}
 
       - name: Upload build artifact
@@ -81,7 +82,6 @@ jobs:
         run: |
           mkdir -p dist
           gh run download "${GITHUB_RUN_ID}" --name "mcpstore-desktop-darwin-aarch64" --dir dist/darwin-aarch64
-          gh run download "${GITHUB_RUN_ID}" --name "mcpstore-desktop-darwin-x86_64" --dir dist/darwin-x86_64
 
       - name: Generate latest.json
         shell: bash
@@ -95,8 +95,8 @@ jobs:
           tag = f"v{version}"
           base = f"https://github.com/ip2a/mcpstore/releases/download/{tag}"
           platforms = {}
-          for identifier, dirname in (("darwin-aarch64", "darwin-aarch64"), ("darwin-x86_64", "darwin-x86_64")):
-              directory = Path("dist") / dirname
+          for identifier in ("darwin-aarch64",):
+              directory = Path("dist") / identifier
               archive = next(directory.glob("*.app.tar.gz"))
               platforms[identifier] = {
                   "signature": (directory / f"{archive.name}.sig").read_text(encoding="utf-8").strip(),
@@ -119,7 +119,7 @@ jobs:
             gh release create "${tag}" --title "${tag}" --generate-notes --verify-tag "${prerelease[@]}"
           fi
           assets=(dist/darwin-aarch64/*.app.tar.gz dist/darwin-aarch64/*.app.tar.gz.sig \
-            dist/darwin-x86_64/*.app.tar.gz dist/darwin-x86_64/*.app.tar.gz.sig)
+            dist/darwin-aarch64/*.dmg)
           # pre-releases must never feed the Tauri auto-updater channel
           if [ ${#prerelease[@]} -eq 0 ]; then assets+=(dist/latest.json); fi
           gh release upload "${tag}" "${assets[@]}" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ web/dist/
 docs/.venv/
 docs/site/
 release-assets/
+# assembled platform binaries; the entry package's wrapper is source and stays tracked
 npm/packages/*/bin/
+!npm/packages/mcpstore/bin/
 *.tgz
 .obsidian/
 .specstory/

--- a/npm/packages/mcpstore/bin/mcpstore.js
+++ b/npm/packages/mcpstore/bin/mcpstore.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@ip2a/mcpstore-bin-darwin-arm64",
+  "linux-x64": "@ip2a/mcpstore-bin-linux-x64-gnu",
+  "linux-arm64": "@ip2a/mcpstore-bin-linux-arm64-gnu",
+  "win32-x64": "@ip2a/mcpstore-bin-win32-x64-msvc",
+};
+
+const key = `${process.platform}-${process.arch}`;
+const packageName = PLATFORM_PACKAGES[key];
+if (!packageName) {
+  console.error(`[error] mcpstore does not support ${process.platform}-${process.arch}`);
+  process.exit(1);
+}
+
+const binary = process.platform === "win32" ? "mcpstore.exe" : "mcpstore";
+let binaryPath;
+try {
+  binaryPath = require.resolve(`${packageName}/bin/${binary}`);
+} catch {
+  console.error(`[error] Platform package ${packageName} is missing.`);
+  console.error("[hint] Reinstall with optional dependencies enabled: npm install -g @ip2a/mcpstore");
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) {
+  console.error(`[error] Failed to launch mcpstore: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- add `bin/mcpstore.js` wrapper to `@ip2a/mcpstore` — the published 2.3.0 tarball contains only package.json (the bin target never existed), so the npm install path shipped a dead CLI
- except `npm/packages/mcpstore/bin/` from the `npm/packages/*/bin/` gitignore rule that swallowed the wrapper source (root cause of it never landing)
- release-build-desktop: build `app,dmg` bundles — `--bundles dmg` alone skipped the app target, so `createUpdaterArtifacts` never emitted `.app.tar.gz`/`.sig` and every desktop run failed at the collect step
- release-build-desktop: upload the `.dmg` to the release (it was never attached) and drop `x86_64-apple-darwin` / darwin-x86_64 from the matrix and `latest.json`, aligning with #69 (Intel support removed)

## Test plan
- [x] wrapper verified against a stub platform package: success path, exit-code passthrough, missing-package error, unsupported-platform error
- [x] `npm pack --dry-run`: tarball now includes `bin/mcpstore.js`
- [x] workflow YAML parses; `git check-ignore` confirms platform binaries still ignored, wrapper tracked